### PR TITLE
fix(search): focus when clicked

### DIFF
--- a/src/components/search/MeilisearchInstantSearch.css
+++ b/src/components/search/MeilisearchInstantSearch.css
@@ -97,3 +97,14 @@
   font-size: 0.875rem;
   color: #4b5563; /* text-gray-800 */
 }
+
+input.ais-SearchBox-input:not(:focus)::placeholder {
+  position: relative;
+  left: 20px;
+  color: #9ca3af; /* text-gray-400 */
+}
+
+/* #root > div > div.container.mx-auto.px-4.py-8 > div > div.lg\:col-span-3 > div.mb-6 > div > form::before */
+form.ais-SearchBox-form:focus-within::before {
+  display: none;
+}


### PR DESCRIPTION
This pull request makes minor improvements to the search box styling in `MeilisearchInstantSearch.css`, specifically targeting the placeholder positioning and the appearance of the form when focused.

- Search box UI improvements:
  * Adjusted the placeholder text in `input.ais-SearchBox-input` to be indented 20px and set its color to a lighter gray for better visual clarity.
  * Modified the search form (`form.ais-SearchBox-form`) so that any decorative `::before` pseudo-element is hidden when the form is focused, improving focus state appearance.

**Screenshots**
Not focused
<img width="1100" height="97" alt="Screenshot 2025-09-23 at 12 07 39 AM" src="https://github.com/user-attachments/assets/e498d1eb-a67b-4de3-a7b0-a5e218a88770" />

Focused
<img width="1106" height="94" alt="Screenshot 2025-09-23 at 12 07 44 AM" src="https://github.com/user-attachments/assets/180148e4-2feb-4d57-9272-7ec32d894cd4" />
